### PR TITLE
created trident quote endpoint structs

### DIFF
--- a/api-reference/tridentQuoteAPI.yml
+++ b/api-reference/tridentQuoteAPI.yml
@@ -14,22 +14,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GSQuoteResponse"
-  /broker-quote:
+  /trident-quote:
     get:
-      summary: Get Broker Quote Response
+      summary: Get Trident Quote Response
       responses:
         "200":
           description: A Quote Response object from the broker after creating an email reply draft
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BrokerQuoteResponse"
+                $ref: "#/components/schemas/TridentQuoteResponse"
 components:
   schemas:
     GSQuoteResponse:
       type: object
       properties:
         userEmail:
+          type: string
+        senderEmail:
           type: string
         stops:
           type: array
@@ -49,15 +51,18 @@ components:
           type: number
         laneRateConfidenceLevel:
           type: number
-        lowConfidenceThreshold:
-          type: number
-        mediumConfidenceThreshold:
-          type: number
       required:
         - userEmail
+        - senderEmail
         - stops
         - selectedRateName
-    BrokerQuoteResponse:
+        - networkLaneRateDistance
+        - networkLaneRateTargetBuy
+        - networkLaneRateConfidenceLevel
+        - laneRateDistance
+        - laneRateTargetBuy
+        - laneRateConfidenceLevel
+    TridentQuoteResponse:
       type: object
       properties:
         userEmail:
@@ -82,6 +87,8 @@ components:
         - carrierCost
         - margin
         - targetSell
+        - draftResponse
+        - recipientEmail
     Stop:
       type: object
       properties:

--- a/api-reference/tridentQuoteAPI.yml
+++ b/api-reference/tridentQuoteAPI.yml
@@ -31,7 +31,7 @@ components:
       properties:
         userEmail:
           type: string
-        senderEmail:
+        customerEmail:
           type: string
         stops:
           type: array
@@ -53,7 +53,7 @@ components:
           type: number
       required:
         - userEmail
-        - senderEmail
+        - customerEmail
         - stops
         - selectedRateName
         - networkLaneRateDistance
@@ -79,7 +79,7 @@ components:
           type: number
         draftResponse:
           type: string
-        recipientEmail:
+        customerEmail:
           type: string
       required:
         - userEmail
@@ -88,7 +88,7 @@ components:
         - margin
         - targetSell
         - draftResponse
-        - recipientEmail
+        - customerEmail
     Stop:
       type: object
       properties:

--- a/api-reference/tridentQuoteAPI.yml
+++ b/api-reference/tridentQuoteAPI.yml
@@ -1,0 +1,108 @@
+openapi: 3.0.1
+info:
+  title: Quick Quote API
+  description: This API captures two interactions. The first is the quote response the broker sees from Greenscreens, and the second is the quote response the broker is sending to the customer.
+  version: "1.0"
+paths:
+  /gs-quote:
+    get:
+      summary: Get GS Quote Response
+      responses:
+        "200":
+          description: A Greenscreens QuoteResponse object with user email
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GSQuoteResponse"
+  /broker-quote:
+    get:
+      summary: Get Broker Quote Response
+      responses:
+        "200":
+          description: A Quote Response object from the broker after creating an email reply draft
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BrokerQuoteResponse"
+components:
+  schemas:
+    GSQuoteResponse:
+      type: object
+      properties:
+        userEmail:
+          type: string
+        stops:
+          type: array
+          items:
+            $ref: "#/components/schemas/Stop"
+        selectedRateName:
+          $ref: "#/components/schemas/SelectedCarrierType"
+        networkLaneRateDistance:
+          type: number
+        networkLaneRateTargetBuy:
+          type: number
+        networkLaneRateConfidenceLevel:
+          type: number
+        laneRateDistance:
+          type: number
+        laneRateTargetBuy:
+          type: number
+        laneRateConfidenceLevel:
+          type: number
+        lowConfidenceThreshold:
+          type: number
+        mediumConfidenceThreshold:
+          type: number
+      required:
+        - userEmail
+        - stops
+        - selectedRateName
+    BrokerQuoteResponse:
+      type: object
+      properties:
+        userEmail:
+          type: string
+        stops:
+          type: array
+          items:
+            $ref: "#/components/schemas/Stop"
+        carrierCost:
+          type: number
+        margin:
+          type: number
+        targetSell:
+          type: number
+        draftResponse:
+          type: string
+        recipientEmail:
+          type: string
+      required:
+        - userEmail
+        - stops
+        - carrierCost
+        - margin
+        - targetSell
+    Stop:
+      type: object
+      properties:
+        order:
+          type: integer
+        city:
+          type: string
+        state:
+          type: string
+        zip:
+          type: string
+        country:
+          type: string
+      required:
+        - order
+        - city
+        - state
+        - zip
+        - country
+    SelectedCarrierType:
+      type: string
+      enum:
+        - NETWORK
+        - BUYPOWER


### PR DESCRIPTION
Trident wants to store quote interactions their brokers have on Drumkit. We are willing to provide data through two endpoints.

1. gs-quote, this endpoint reflects the data the broker sees after they click the "Get Quick Quote" button.
2. broker-quote, this endpoint reflects the quoting information that the broker has decided on. We plan on hitting this endpoint after the broker clicks "Create Reply Draft"

@jinyanzang let me know what you think about the data structures.